### PR TITLE
fix(qabot): Ignore .gihooks folder

### DIFF
--- a/qabot/manifests_checker.py
+++ b/qabot/manifests_checker.py
@@ -49,7 +49,7 @@ class ManifestsChecker():
     """
     # repos_with_manifests = ['cdis-manifest', 'gitops-qa']
     repos_with_manifests = ['cdis-manifest']
-    to_be_ignored = ['releases', 'login.bionimbus.org']
+    to_be_ignored = ['.githooks', 'releases', 'login.bionimbus.org']
     list_of_environments = "```\n"
     environments_count = 0
 


### PR DESCRIPTION
a new folder has been added and it is breaking the qa-bot logic. Let us ignore this folder.