### PR TITLE
fix(qa-bot): Ignore github actions folder

### DIFF
--- a/qabot/manifests_checker.py
+++ b/qabot/manifests_checker.py
@@ -49,7 +49,7 @@ class ManifestsChecker():
     """
     # repos_with_manifests = ['cdis-manifest', 'gitops-qa']
     repos_with_manifests = ['cdis-manifest']
-    to_be_ignored = ['.githooks', 'releases', 'login.bionimbus.org']
+    to_be_ignored = ['.github', '.githooks', 'releases', 'login.bionimbus.org']
     list_of_environments = "```\n"
     environments_count = 0
 


### PR DESCRIPTION
The bot fails while trying to scan the github hooks folder 🤦 
```
INFO:__main__:user **** just sent a msg: <@***> whereis release 2020.04
INFO:__main__:args: ['release', '2020.04']
ERROR:lib.httplib:request to https://raw.githubusercontent.com/uc-cdis/cdis-manifest/master/.github/manifest.json failed due to the following error: 404 Client Error: Not Found for url: https://raw.githubusercontent.com/uc-cdis/cdis-manifest/master/.github/manifest.json
```