### PR TITLE
sanitize slack input + black formatting

### DIFF
--- a/qabot/lib/jenkinslib.py
+++ b/qabot/lib/jenkinslib.py
@@ -62,7 +62,7 @@ class JenkinsLib:
         # convert list of params into dictionary
         pr = self.prepare_remote_build_request(job_name, params)
         err, resp = self.invoke_job(pr)
-        if resp.status_code == 201:
+        if resp != None and resp.status_code == 201:
             metadata_url = "{}/{}/lastBuild/api/json".format(self.base_url, job_name,)
             log.debug(
                 "Job triggered successfully. Checking the json metadata: {}".format(
@@ -75,9 +75,9 @@ class JenkinsLib:
             log.debug(job_metadata.json().keys())
             next_build_number = int(job_metadata.json()["id"]) + 1
             return None, next_build_number
-        else:
-            print("Job could not be invoked.")
-            return err, None
+
+        print("Job could not be invoked.")
+        return err, None
 
     def get_status_of_job(self, job_name, job_id):
         job_metadata = requests.get(

--- a/qabot/qabot.py
+++ b/qabot/qabot.py
@@ -103,7 +103,10 @@ def capture_messages(**payload):
         if "<@UQKCGCU1H>" in data["text"]:
             log.info("user {} just sent a msg: {}".format(user, data["text"]))
 
-            msg_parts = data["text"].split(" ")
+            raw_command = data["text"].replace("\xa0", " ")
+            raw_command = raw_command.replace("“", '"').replace("”", '"')
+            msg_parts_split = raw_command.split(" ")
+            msg_parts = list(filter(None, msg_parts_split))
             # identify command
             if len(msg_parts) > 1:
                 command = msg_parts[1]


### PR DESCRIPTION
Sanitize Slack input.
Get rid of weird characters, eliminate white spaces and weird double-quotes injected through copy & paste.