### PR TITLE
Get more information when replay failed

### DIFF
--- a/qabot/lib/jenkinslib.py
+++ b/qabot/lib/jenkinslib.py
@@ -87,7 +87,7 @@ class JenkinsLib:
             auth=("PlanXCyborg", self.jenkins_user_api_token),
         )
         if resp.status_code != 200:
-            err_msg = "The replay operation failed. Details: {}".format(resp.reason)
+            err_msg = "The replay operation failed. Details: {}".format(resp.json()['message'])
             log.error(err_msg)
             err = Exception(err_msg)
             return err, None

--- a/qabot/lib/jenkinslib.py
+++ b/qabot/lib/jenkinslib.py
@@ -87,7 +87,10 @@ class JenkinsLib:
             auth=("PlanXCyborg", self.jenkins_user_api_token),
         )
         if resp.status_code != 200:
-            err_msg = "The replay operation failed. Details: {}".format(resp.json()['message'])
+            if 'message' in resp.json().keys():
+                err_msg = "The replay operation failed. Details: {}".format(resp.json()['message'])
+            else:
+                err_msg = "The replay operation failed. Details: {}".format(resp.reason)
             log.error(err_msg)
             err = Exception(err_msg)
             return err, None


### PR DESCRIPTION
When the replay operation failed (status code is not 200), it sent this slack notification:

> Something wrong happened :facepalm:. Deets: The replay operation failed. Details: Server Error

To get more information, modify the details to include error messages.