### PR TITLE
Fix job id computation

### DIFF
--- a/qabot/lib/jenkinslib.py
+++ b/qabot/lib/jenkinslib.py
@@ -132,7 +132,7 @@ class JenkinsLib:
             time.sleep(10)
             try:
                 log.debug(job_metadata.json().keys())
-                next_build_number = int(job_metadata.json()["id"]) + 1
+                next_build_number = int(job_metadata.json()["id"])
             except JSONDecodeError as jde:
                 return "err: Could not determine the next build number :(", None
             return None, next_build_number


### PR DESCRIPTION
After the jenkins update there seems to be a change in the job id is calculated and does not require explicit addition of 1
<!--
Make sure to follow the DEV guidelines (https://gen3.org/resources/developer/dev-introduction/) before asking for review.

- Describe what this pull request does.
- Add short descriptive bullet points for each section if relevant. Keep in mind that they will be parsed automatically to generate official release notes.
- Test manually.
- Maintain or increase the test coverage (if relevant).
- Update the documentation, or justify if not needed.

-->

### New Features


### Breaking Changes


### Bug Fixes


### Improvements


### Dependency updates


### Deployment changes
<!-- This section should only contain important things devops should know when updating service versions. -->
